### PR TITLE
Simple formatting of time variables

### DIFF
--- a/docs/shaman.1
+++ b/docs/shaman.1
@@ -85,7 +85,7 @@ The following format specifiers may be used in the format string:
 .PP
 .Vb
 %%    A literal percent sign
-%a    Time of data receipt       (unixtime)
+%a    Time of data receipt       (%H:%M:%S)
 %b    Barometric pressure        (hectoPascals)
 %c    Weather condition string
 %C    Weather condition code
@@ -99,8 +99,8 @@ The following format specifiers may be used in the format string:
 %L    Longitude                  (degrees)
 %p    Precipitation              (in | mm)
 %P    Relative humidity          (percent)
-%s    Time of sunrise            (unixtime)
-%S    Time of sunset             (unixtime)
+%s    Time of sunrise            (%H:%M:%S)
+%S    Time of sunset             (%H:%M:%S)
 %t    Current temperature        (°F | °C)
 %w    Sustained wind speed       (mph|mps)
 %W    Gusting wind speed         (mph|mps)

--- a/docs/shaman.tex
+++ b/docs/shaman.tex
@@ -51,7 +51,7 @@ The following format specifiers may be used in the format string:
 % Verify and finish documenting units for each value
 \begin{verbatim}
 %%    A literal percent sign
-%a    Time of data receipt       (unixtime)
+%a    Time of data receipt       (%H:%M:%S)
 %b    Barometric pressure        (hectoPascals)
 %c    Weather condition string
 %C    Weather condition code
@@ -65,8 +65,8 @@ The following format specifiers may be used in the format string:
 %L    Longitude                  (degrees)
 %p    Precipitation              (in | mm)
 %P    Relative humidity          (percent)
-%s    Time of sunrise            (unixtime)
-%S    Time of sunset             (unixtime)
+%s    Time of sunrise            (%H:%M:%S)
+%S    Time of sunset             (%H:%M:%S)
 %t    Current temperature        (°F | °C)
 %w    Sustained wind speed       (mph|mps)
 %W    Gusting wind speed         (mph|mps)

--- a/docs/strfweather.3
+++ b/docs/strfweather.3
@@ -38,7 +38,7 @@ The following format specifiers are permitted:
 .PP
 .Vb
 %%    A literal percent sign
-%a    Time of data receipt       (unixtime)
+%a    Time of data receipt       (%H:%M:%S)
 %b    Barometric pressure        (hectoPascals)
 %c    Weather condition string
 %C    Weather condition code
@@ -52,8 +52,8 @@ The following format specifiers are permitted:
 %L    Longitude                  (degrees)
 %p    Precipitation              (in | mm)
 %P    Relative humidity          (percent)
-%s    Time of sunrise            (unixtime)
-%S    Time of sunset             (unixtime)
+%s    Time of sunrise            (%H:%M:%S)
+%S    Time of sunset             (%H:%M:%S)
 %t    Current temperature        (°F | °C)
 %w    Sustained wind speed       (mph|kmph)
 %W    Gusting wind speed         (mph|kmph)

--- a/docs/strfweather.tex
+++ b/docs/strfweather.tex
@@ -22,7 +22,7 @@ The following format specifiers are permitted:
 
 \begin{verbatim}
 %%    A literal percent sign
-%a    Time of data receipt       (unixtime)
+%a    Time of data receipt       (%H:%M:%S)
 %b    Barometric pressure        (hectoPascals)
 %c    Weather condition string
 %C    Weather condition code
@@ -36,8 +36,8 @@ The following format specifiers are permitted:
 %L    Longitude                  (degrees)
 %p    Precipitation              (in | mm)
 %P    Relative humidity          (percent)
-%s    Time of sunrise            (unixtime)
-%S    Time of sunset             (unixtime)
+%s    Time of sunrise            (%H:%M:%S)
+%S    Time of sunset             (%H:%M:%S)
 %t    Current temperature        (°F | °C)
 %w    Sustained wind speed       (mph|kmph)
 %W    Gusting wind speed         (mph|kmph)

--- a/src/weather.c
+++ b/src/weather.c
@@ -44,8 +44,8 @@ const char * c_dir [] = {
 };
 
 // Function drawn from Petri Lehtinen's GitHub Jansson example
-static 
-size_t 
+static
+size_t
 write_data_buffer (void * ptr, size_t size, size_t nmemb, void * stream) {
 
     struct json_write_result * result = (struct json_write_result * )stream;
@@ -61,7 +61,7 @@ write_data_buffer (void * ptr, size_t size, size_t nmemb, void * stream) {
 }
 
 // Fetch JSON from file
-struct json_write_result * 
+struct json_write_result *
 owm_fetch_local (const char * json_file_path) {
 
     char * data = calloc(1, BUFFER_SIZE);
@@ -85,8 +85,8 @@ owm_fetch_local (const char * json_file_path) {
 }
 
 // Fetch JSON from OpenWeatherMap
-struct json_write_result * 
-owm_fetch_remote (const char method, const char * location, const char scale, 
+struct json_write_result *
+owm_fetch_remote (const char method, const char * location, const char scale,
                   const char * file_cache_path, const char * api_key) {
 
     CURL * handle;
@@ -125,12 +125,12 @@ owm_fetch_remote (const char method, const char * location, const char scale,
     handle = curl_easy_init();
 
     if ( handle ) {
-        const char * provider = 
+        const char * provider =
             "http://api.openweathermap.org/data/2.5/weather";
 
         char * encoded_location = curl_easy_escape(handle, location, 0);
-        
-        snprintf(url, sizeof(url), "%s?%s=%s&units=%s&APPID=%s", provider, 
+
+        snprintf(url, sizeof(url), "%s?%s=%s&units=%s&APPID=%s", provider,
                  fetch_method, encoded_location, fetch_scale, api_key);
 
         curl_easy_setopt(handle, CURLOPT_URL, url);
@@ -139,7 +139,7 @@ owm_fetch_remote (const char method, const char * location, const char scale,
 
         result = curl_easy_perform(handle);
         if ( result != CURLE_OK ) {
-            fprintf(stderr, "Failed to retrieve data (%s)\n", 
+            fprintf(stderr, "Failed to retrieve data (%s)\n",
                     curl_easy_strerror(result));
 
             curl_easy_cleanup(handle);
@@ -172,7 +172,7 @@ owm_fetch_remote (const char method, const char * location, const char scale,
 }
 
 // Read JSON into a weather struct
-struct weather * 
+struct weather *
 owm_read (struct json_write_result * json) {
 
     json_error_t error;
@@ -196,17 +196,17 @@ owm_read (struct json_write_result * json) {
                     json_t * sub_value;
                     json_object_foreach(root_value, sub_key, sub_value) {
                         if ( root_key[1] == 'l' ) {
-                            fetched_weather.clouds = 
+                            fetched_weather.clouds =
                                 json_number_value(sub_value);
                         } else if ( root_key[2] == 'o' ) {
                             if ( sub_key[1] == 'o' ) {
-                                fetched_weather.longitude = 
+                                fetched_weather.longitude =
                                     json_number_value(sub_value);
                             } else if ( sub_key[1] == 'a' ) {
-                                fetched_weather.latitude = 
+                                fetched_weather.latitude =
                                     json_number_value(sub_value);
                             }
-                        } 
+                        }
                     }
                 } break;
 
@@ -230,23 +230,23 @@ owm_read (struct json_write_result * json) {
                         switch ( sub_key[0] ) {
                             case 't':
                                 if ( strlen(sub_key) == 4 ) {
-                                    fetched_weather.temperature = 
+                                    fetched_weather.temperature =
                                         json_number_value(sub_value);
                                 } else if ( sub_key[6] == 'i' ) {
-                                    fetched_weather.temp_min = 
+                                    fetched_weather.temp_min =
                                         json_number_value(sub_value);
                                 } else if ( sub_key[6] == 'a' ) {
-                                    fetched_weather.temp_max = 
+                                    fetched_weather.temp_max =
                                         json_number_value(sub_value);
                                 } break;
-    
+
                             case 'p':
-                                fetched_weather.pressure = 
+                                fetched_weather.pressure =
                                     json_number_value(sub_value);
                                 break;
-    
+
                             case 'h':
-                                fetched_weather.humidity = 
+                                fetched_weather.humidity =
                                     json_number_value(sub_value);
                                 break;
                         }
@@ -268,27 +268,27 @@ owm_read (struct json_write_result * json) {
                             case 'y':
                                 switch ( sub_key[4] ) {
                                     case 'i':
-                                        fetched_weather.sunrise = 
+                                        fetched_weather.sunrise =
                                             json_integer_value(sub_value);
                                         break;
 
                                     case 'e':
-                                        fetched_weather.sunset = 
+                                        fetched_weather.sunset =
                                             json_integer_value(sub_value);
                                         break;
 
                                     case 't':
-                                        fetched_weather.country = 
+                                        fetched_weather.country =
                                             json_string_value(sub_value);
 
                                         if ( !fetched_weather.country ) {
-                                            fetched_weather.country = 
+                                            fetched_weather.country =
                                                 "Unavailable";
                                         } break;
                                 } break;
-    
+
                             case 'n':
-                                fetched_weather.precipitation_3h = 
+                                fetched_weather.precipitation_3h =
                                     json_number_value(sub_value);
                                 break;
                         }
@@ -303,12 +303,12 @@ owm_read (struct json_write_result * json) {
                     json_object_foreach(weather, sub_key, sub_value) {
                         switch ( sub_key[1] ) {
                             case 'd':
-                                fetched_weather.weather_code = 
+                                fetched_weather.weather_code =
                                     json_integer_value(sub_value);
                                 break;
 
                             case 'e':
-                                fetched_weather.condition = 
+                                fetched_weather.condition =
                                     json_string_value(sub_value);
 
                                 if ( !fetched_weather.condition ) {
@@ -322,17 +322,17 @@ owm_read (struct json_write_result * json) {
                     json_object_foreach(root_value, sub_key, sub_value) {
                         switch ( sub_key[0] ) {
                             case 's':
-                                fetched_weather.wind_speed = 
+                                fetched_weather.wind_speed =
                                     json_number_value(sub_value);
                                 break;
-    
+
                             case 'g':
-                                fetched_weather.wind_gust = 
+                                fetched_weather.wind_gust =
                                     json_number_value(sub_value);
                                 break;
-    
+
                             case 'd':
-                                fetched_weather.wind_direction = 
+                                fetched_weather.wind_direction =
                                     json_number_value(sub_value);
                                 break;
                         }
@@ -345,7 +345,7 @@ owm_read (struct json_write_result * json) {
                     json_t * sub_value;
                     json_object_foreach(root_value, sub_key, sub_value) {
                         if ( sub_key[0] == '3' ) {
-                            fetched_weather.precipitation_3h = 
+                            fetched_weather.precipitation_3h =
                                 json_number_value(sub_value);
                         }
                     }
@@ -358,8 +358,8 @@ owm_read (struct json_write_result * json) {
     return &fetched_weather;
 }
 
-int 
-check_if_stale (const char * cache_path, const unsigned int cache_update_time, 
+int
+check_if_stale (const char * cache_path, const unsigned int cache_update_time,
                 const char verbosity) {
 
     struct stat cache_stats;
@@ -370,16 +370,16 @@ check_if_stale (const char * cache_path, const unsigned int cache_update_time,
         return ((time(NULL) - cache_stats.st_mtim.tv_sec) >= cache_update_time);
     } else {
         if ( verbosity > 0 ) {
-            fprintf(stderr, 
-                    "Determining if cache should be freshened failed: %s\n", 
+            fprintf(stderr,
+                    "Determining if cache should be freshened failed: %s\n",
                     strerror(errsv));
         } return -1;
     }
 }
 
-struct weather * 
-owm_easy (const char method, const char * location, const char scale, 
-          const char * file_cache_path, const unsigned int cache_update_time, 
+struct weather *
+owm_easy (const char method, const char * location, const char scale,
+          const char * file_cache_path, const unsigned int cache_update_time,
           const char * api_key, const char verbosity) {
 
     struct json_write_result * json;
@@ -387,7 +387,7 @@ owm_easy (const char method, const char * location, const char scale,
 
     if ( file_cache_path ) {
         if ( check_if_stale(file_cache_path, cache_update_time, verbosity) ) {
-            json = owm_fetch_remote(method, location, scale, file_cache_path, 
+            json = owm_fetch_remote(method, location, scale, file_cache_path,
                                     api_key);
         } else {
             json = owm_fetch_local(file_cache_path);
@@ -395,7 +395,7 @@ owm_easy (const char method, const char * location, const char scale,
             sscanf(location, "%[^,]", city);
             if ( !strstr(json->data, city) ) {
                 free(json->data);
-                json = owm_fetch_remote(method, location, scale, 
+                json = owm_fetch_remote(method, location, scale,
                                         file_cache_path, api_key);
             } free(city);
         }
@@ -407,10 +407,9 @@ owm_easy (const char method, const char * location, const char scale,
     return wthr;
 }
 
-// TODO: Add support for formatting time variables
 // TODO: Add support for Apparent Temperature
-size_t 
-strfweather (char * dest_str, size_t n, const char * format, 
+size_t
+strfweather (char * dest_str, size_t n, const char * format,
              const struct weather * w) {
 
     int cl = 0;
@@ -423,7 +422,7 @@ strfweather (char * dest_str, size_t n, const char * format,
                     break;
 
                 case 'a':
-                    cl += snprintf(dest_str + cl, n - cl, "%ld", w->dt);
+                    cl += strftime(dest_str + cl, n - cl, "%H:%M:%S", localtime(&w->dt));
                     continue;
 
                 case 'b':
@@ -435,7 +434,7 @@ strfweather (char * dest_str, size_t n, const char * format,
                     continue;
 
                 case 'C':
-                    cl += snprintf(dest_str + cl, n - cl, "%d", 
+                    cl += snprintf(dest_str + cl, n - cl, "%d",
                                    w->weather_code);
                     continue;
 
@@ -472,7 +471,7 @@ strfweather (char * dest_str, size_t n, const char * format,
                     continue;
 
                 case 'p':
-                    cl += snprintf(dest_str + cl, n - cl, "%g", 
+                    cl += snprintf(dest_str + cl, n - cl, "%g",
                                    w->precipitation_3h);
                     continue;
 
@@ -481,11 +480,11 @@ strfweather (char * dest_str, size_t n, const char * format,
                     continue;
 
                 case 's':
-                    cl += snprintf(dest_str + cl, n - cl, "%ld", w->sunrise);
+                    cl += strftime(dest_str + cl, n - cl, "%H:%M:%S", localtime(&w->sunrise));
                     continue;
 
                 case 'S':
-                    cl += snprintf(dest_str + cl, n - cl, "%ld", w->sunset);
+                    cl += strftime(dest_str + cl, n - cl, "%H:%M:%S", localtime(&w->sunset));
                     continue;
 
                 case 't':
@@ -505,7 +504,7 @@ strfweather (char * dest_str, size_t n, const char * format,
                     continue;
 
                 case 'x':
-                    cl += snprintf(dest_str + cl, n - cl, "%g", 
+                    cl += snprintf(dest_str + cl, n - cl, "%g",
                                    w->wind_direction);
                     continue;
 
@@ -526,7 +525,7 @@ strfweather (char * dest_str, size_t n, const char * format,
             cl += snprintf(dest_str + cl, n - cl, "%c", *format);
         }
     }
-    
+
     return (cl == n ? 0 : cl);
 }
 


### PR DESCRIPTION
I've added simple formatting of time time variables (for `%a`, `%s`, `%S`) in strftime `%H:%M:%S` format. Change itself is 3 lines, for 3 variables, format is hard-coded inline. I just wanted to see value of these variables. I think `%H:%M:%S` works reasonably well and don't have to be configurable (well at least for now it's not, yet it does the job). Since I was editing `weather.c` I've removed all extraneous spaces (same can be done with `shaman.c`). I've edited also `docs` to include format there. Probably whole thing can be improved in various ways, yet this seems to me as reasonable output format / handling for start.

If this fits the bill, consider merging. Thanks for shaman! ;)
