### PR TITLE
st_mtime fix

### DIFF
--- a/src/weather.c
+++ b/src/weather.c
@@ -80,7 +80,7 @@ owm_fetch_local (const char * json_file_path) {
 
     FILE * json_fp = fopen(json_file_path, "r");
 
-    size_t bytes_read = fread(written_result.data, BUFFER_SIZE, 1, json_fp);
+    fread(written_result.data, BUFFER_SIZE, 1, json_fp);
 
     if ( ferror(json_fp) ) {
         fclose(json_fp);
@@ -160,10 +160,9 @@ owm_fetch_remote (const char method, const char * location, const char scale,
         curl_free(encoded_location);
     }
 
-    int bytes_written;
     if ( file_cache_path ) {
         FILE * json_cache = fopen(file_cache_path, "w");
-        bytes_written = fwrite(written_result.data, BUFFER_SIZE, 1, json_cache);
+        fwrite(written_result.data, BUFFER_SIZE, 1, json_cache);
 
         if ( ferror(json_cache) ) {
             fclose(json_cache);


### PR DESCRIPTION
st_mtim may or may not be visible, stat(2) says it requires _BSD_SOURCE and my gcc actually throws an error there with -std=c11.
As long as nanoseconds are not needed, it's better to use common st_mtime.

Also, with -Wall -Wpedantic gcc complains about unused variables.
